### PR TITLE
fix a number of bugs

### DIFF
--- a/examples/ex_bayarri_discrepancy.ipynb
+++ b/examples/ex_bayarri_discrepancy.ipynb
@@ -29,12 +29,12 @@
     "import warnings\n",
     "from itertools import product\n",
     "\n",
-    "import impala.sc.post_process as pp\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "import pandas as pd\n",
     "import pyBASS as pb\n",
     "\n",
+    "import impala.superCal.post_process as pp\n",
     "from impala import superCal as sc\n",
     "\n",
     "# https://github.com/lanl/pyBASS"

--- a/src/impala/__init__.py
+++ b/src/impala/__init__.py
@@ -1,5 +1,11 @@
+from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _get_version
 
 from . import physics, superCal
 
-__version__ = _get_version("impala-calib")
+try:
+    __version__ = _get_version("impala-calib")
+except PackageNotFoundError:
+    __version__ = (
+        "local"  ## use this if impala is not installed,  but imported locally
+    )

--- a/src/impala/superCal/impala_noprobit_emu.py
+++ b/src/impala/superCal/impala_noprobit_emu.py
@@ -9,7 +9,7 @@
 ###############
 
 import time
-from collections import namedtuple
+from collections import defaultdict, namedtuple
 from math import floor, log, sqrt
 from multiprocessing import Pool
 
@@ -34,7 +34,6 @@ np.seterr(under="ignore")
 ###############################################################
 ### CalibSetup Class for Initializing the Calibration Model ###
 ###############################################################
-from collections import defaultdict
 
 
 def is_valid_mapping(theta_inds, s2_inds):
@@ -102,6 +101,8 @@ class CalibSetup:
         self.ig_a = []
         self.ig_b = []
         self.wt = []
+        self.sd_lower = []
+        self.sd_upper = []
         self.s2_ind = []
         self.s2_exp_ind = []
         self.ns2 = []
@@ -428,13 +429,16 @@ def chol_sample_nper(means, covs, n):
 
 
 def chol_sample_1per_constraints(
-    means, covs, cf, bounds_mat, bounds_keys, bounds, consts
+    means, covs, cf, bounds_mat, bounds_keys, bounds, consts, maxiter=1000000
 ):
     """Sample with constraints.  If fail constraints, resample."""
     chols = cholesky(covs)
     cand = means + np.einsum("ijk,ik->ij", chols, normal(size=means.shape))
     good = cf(tran_unif(cand, bounds_mat, bounds_keys), bounds, consts)
+    i=1
     while np.any(np.logical_not(good)):
+        if i>maxiter:
+            raise ValueError(f"Failed to find samples that fulfill the constraints after {maxiter} iterations.")
         cand[np.where(np.logical_not(good))] = +means[
             np.logical_not(good)
         ] + np.einsum(
@@ -446,11 +450,12 @@ def chol_sample_1per_constraints(
             tran_unif(cand[np.logical_not(good)], bounds_mat, bounds_keys),
             bounds,
         )
+        i += 1
     return cand
 
 
 def chol_sample_nper_constraints(
-    means, covs, n, cf, bounds_mat, bounds_keys, bounds, consts
+    means, covs, n, cf, bounds_mat, bounds_keys, bounds, consts, maxiter=1000000
 ):
     """Sample with constraints.  If fail constraints, resample."""
     chols = cholesky(covs)
@@ -459,7 +464,12 @@ def chol_sample_nper_constraints(
     )
     for i in range(cand.shape[0]):
         goodi = cf(tran_unif(cand[i], bounds_mat, bounds_keys), bounds, consts)
+        j = 0
         while np.any(np.logical_not(goodi)):
+            if j > maxiter:
+                raise ValueError(
+                    f"Failed to find samples that fulfill the constraints after {maxiter} iterations."
+                )
             cand[i, np.where(np.logical_not(goodi))[0]] = +means[i] + np.einsum(
                 "ik,nk->ni",
                 chols[i],
@@ -473,6 +483,7 @@ def chol_sample_nper_constraints(
                 ),
                 bounds,
             )
+            j += 1
     return cand
 
 
@@ -1696,7 +1707,7 @@ def calibHier_v2(setup):
                 ])
             )
             != 1
-        ) and ("gibbs" in setup.models[i].s2 == "gibbs"):
+        ) and (setup.models[i].s2 == "gibbs"):
             setup.models[i].s2 = "MH"
             print(
                 "Gibbs sampling for s2 only valid if weights are the same for all observations with same s2. Reverting to MH. "
@@ -2934,13 +2945,13 @@ def calibPool_v2(setup):
         tran_unif(theta_start0, setup.bounds_mat, setup.bounds.keys()),
         setup.bounds,
     )
-    while np.any(~good):
-        theta_start0[np.where(~good)] = initfunc_unif(
-            size=[(~good).sum(), setup.p]
+    while np.any(np.logical_not(good)):
+        theta_start0[np.where(np.logical_not(good))] = initfunc_unif(
+            size=[(np.logical_not(good)).sum(), setup.p]
         )
-        good[np.where(~good)] = setup.checkConstraints(
+        good[np.where(np.logical_not(good))] = setup.checkConstraints(
             tran_unif(
-                theta_start0[np.where(~good)],
+                theta_start0[np.where(np.logical_not(good))],
                 setup.bounds_mat,
                 setup.bounds.keys(),
             ),

--- a/src/impala/superCal/impala_noprobit_emu.py
+++ b/src/impala/superCal/impala_noprobit_emu.py
@@ -435,7 +435,7 @@ def chol_sample_1per_constraints(
     chols = cholesky(covs)
     cand = means + np.einsum("ijk,ik->ij", chols, normal(size=means.shape))
     good = cf(tran_unif(cand, bounds_mat, bounds_keys), bounds, consts)
-    j = 1
+    j = 0
     while np.any(np.logical_not(good)):
         if j > maxiter:
             raise ValueError(

--- a/src/impala/superCal/impala_noprobit_emu.py
+++ b/src/impala/superCal/impala_noprobit_emu.py
@@ -437,7 +437,7 @@ def chol_sample_1per_constraints(
     good = cf(tran_unif(cand, bounds_mat, bounds_keys), bounds, consts)
     j = 0
     while np.any(np.logical_not(good)):
-        if j > maxiter:
+        if j >= maxiter:
             raise ValueError(
                 f"Failed to find samples that fulfill the constraints after {maxiter} iterations."
             )
@@ -468,7 +468,7 @@ def chol_sample_nper_constraints(
         goodi = cf(tran_unif(cand[i], bounds_mat, bounds_keys), bounds, consts)
         j = 0
         while np.any(np.logical_not(goodi)):
-            if j > maxiter:
+            if j >= maxiter:
                 raise ValueError(
                     f"Failed to find samples that fulfill the constraints after {maxiter} iterations."
                 )

--- a/src/impala/superCal/impala_noprobit_emu.py
+++ b/src/impala/superCal/impala_noprobit_emu.py
@@ -441,7 +441,7 @@ def chol_sample_1per_constraints(
             raise ValueError(
                 f"Failed to find samples that fulfill the constraints after {maxiter} iterations."
             )
-        cand[np.where(np.logical_not(good))] = +means[
+        cand[np.where(np.logical_not(good))] = means[
             np.logical_not(good)
         ] + np.einsum(
             "ijk,ik->ij",
@@ -472,7 +472,7 @@ def chol_sample_nper_constraints(
                 raise ValueError(
                     f"Failed to find samples that fulfill the constraints after {maxiter} iterations."
                 )
-            cand[i, np.where(np.logical_not(goodi))[0]] = +means[i] + np.einsum(
+            cand[i, np.where(np.logical_not(goodi))[0]] = means[i] + np.einsum(
                 "ik,nk->ni",
                 chols[i],
                 normal(size=((np.logical_not(goodi)).sum(), means.shape[1])),

--- a/src/impala/superCal/impala_noprobit_emu.py
+++ b/src/impala/superCal/impala_noprobit_emu.py
@@ -435,10 +435,12 @@ def chol_sample_1per_constraints(
     chols = cholesky(covs)
     cand = means + np.einsum("ijk,ik->ij", chols, normal(size=means.shape))
     good = cf(tran_unif(cand, bounds_mat, bounds_keys), bounds, consts)
-    i=1
+    i = 1
     while np.any(np.logical_not(good)):
-        if i>maxiter:
-            raise ValueError(f"Failed to find samples that fulfill the constraints after {maxiter} iterations.")
+        if i > maxiter:
+            raise ValueError(
+                f"Failed to find samples that fulfill the constraints after {maxiter} iterations."
+            )
         cand[np.where(np.logical_not(good))] = +means[
             np.logical_not(good)
         ] + np.einsum(

--- a/src/impala/superCal/impala_noprobit_emu.py
+++ b/src/impala/superCal/impala_noprobit_emu.py
@@ -435,9 +435,9 @@ def chol_sample_1per_constraints(
     chols = cholesky(covs)
     cand = means + np.einsum("ijk,ik->ij", chols, normal(size=means.shape))
     good = cf(tran_unif(cand, bounds_mat, bounds_keys), bounds, consts)
-    i = 1
+    j = 1
     while np.any(np.logical_not(good)):
-        if i > maxiter:
+        if j > maxiter:
             raise ValueError(
                 f"Failed to find samples that fulfill the constraints after {maxiter} iterations."
             )
@@ -452,7 +452,7 @@ def chol_sample_1per_constraints(
             tran_unif(cand[np.logical_not(good)], bounds_mat, bounds_keys),
             bounds,
         )
-        i += 1
+        j += 1
     return cand
 
 

--- a/src/impala/superCal/models_withlik.py
+++ b/src/impala/superCal/models_withlik.py
@@ -913,6 +913,8 @@ class ModelF(AbstractModel):
         self.nexp = exp_ind.max() + 1
         self.exp_ind = exp_ind
         self.nd = 0
+        self.discrep_tau = 1.0
+        self.D = None
         self.s2 = s2
         self.constants = None
 
@@ -974,6 +976,8 @@ class ModelF_v2(AbstractModel):
         self.nexp = exp_ind.max() + 1
         self.exp_ind = exp_ind
         self.nd = 0
+        self.discrep_tau = 1.0
+        self.D = None
         self.s2 = s2
         self.constants = None
 
@@ -985,7 +989,7 @@ class ModelF_v2(AbstractModel):
             return np.apply_along_axis(self.mod, 1, parmat_array)
         else:
             # nrep = list(parmat.values())[0].shape[0] // self.nexp
-            nrep = next(iter(parmat.values())) // self.nexp
+            nrep = next(iter(parmat.values())).shape[0] // self.nexp
             self.out_all = self.mod(parmat_array)
             # self.out_all = self.mod(next(iter(parmat.values())))
             self.res_array = np.zeros([nrep, len(self.exp_ind)])
@@ -1038,6 +1042,8 @@ class ModelF_bigdata(AbstractModel):
         self.nexp = exp_ind.max() + 1
         self.exp_ind = exp_ind
         self.nd = 0
+        self.discrep_tau = 1.0
+        self.D = None
         self.s2 = s2
         self.vec = np.linspace(
             1, 16200, 16200
@@ -1072,7 +1078,7 @@ class ModelF_bigdata(AbstractModel):
                     np.where(self.exp_ind == i)[0],
                 )
                 self.res_array[:, np.where(self.exp_ind == i)[0]] = self.mod(
-                    self.parmat_array, inds_to_run
+                    parmat_array, inds_to_run
                 )  # note: this now has a second argument. This is to avoid unnecessary predictions
             return self.res_array
 


### PR DESCRIPTION
- vars missing in init() fcts
- wrong import in one example
- missing .shape[0] attribute in nrep definition in one place
- ~good should be np.logical(good) in _v2 routines as ~ operator does not work well with logical numpy arrays
- avoid potential infinite loops in chol_sample_1per_constraints() and chol_sample_nper_constraints()
- replace undefined self.parmat_array in one place with parmat_array defined a few lines above its use