### PR TITLE
Priors for calibration parameters

### DIFF
--- a/src/impala/superCal/impala_noprobit_emu.py
+++ b/src/impala/superCal/impala_noprobit_emu.py
@@ -17,6 +17,7 @@ import numpy as np
 import scipy
 from numpy.linalg import cholesky, slogdet
 from numpy.random import normal, uniform
+from scipy import stats as sps
 from scipy.special import erf, erfinv, gammaln, multigammaln
 from scipy.stats import invwishart
 
@@ -45,12 +46,108 @@ def is_valid_mapping(theta_inds, s2_inds):
     return all(len(xs) == 1 for xs in error_to_x.values())
 
 
+#############################################################
+### Priors for the calibration parameters (theta)         ###
+#############################################################
+
+# Log densities for the univariate priors that may be placed on a single
+# calibration parameter.  Parameter names match the corresponding R
+# (rImpala) arguments so that the two interfaces stay in sync.
+THETA_PRIOR_LOGPDF = {
+    "normal": lambda x, pp: sps.norm.logpdf(x, loc=pp["mean"], scale=pp["sd"]),
+    "lognormal": lambda x, pp: sps.lognorm.logpdf(
+        x, s=pp["sdlog"], scale=np.exp(pp["meanlog"])
+    ),
+    "beta": lambda x, pp: sps.beta.logpdf(x, pp["shape1"], pp["shape2"]),
+    "uniform": lambda x, pp: sps.uniform.logpdf(
+        x, loc=pp["min"], scale=pp["max"] - pp["min"]
+    ),
+    "gamma": lambda x, pp: sps.gamma.logpdf(
+        x, pp["shape"], scale=1.0 / pp["rate"]
+    ),
+    "cauchy": lambda x, pp: sps.cauchy.logpdf(
+        x, loc=pp["location"], scale=pp["scale"]
+    ),
+}
+
+# Required entries of the `params` dict for each supported distribution.
+THETA_PRIOR_PARAMS = {
+    "normal": ("mean", "sd"),
+    "lognormal": ("meanlog", "sdlog"),
+    "beta": ("shape1", "shape2"),
+    "uniform": ("min", "max"),
+    "gamma": ("shape", "rate"),
+    "cauchy": ("location", "scale"),
+}
+
+
+def eval_theta_priors(theta, priors, tnames=None):
+    """Evaluate the log prior for the calibration parameters.
+
+    :param theta: dict of native-scale parameter vectors keyed by parameter
+        name (one entry per temperature in each vector), as returned by
+        ``tran_unif``.  A 2d array of shape (ntemps, p) may be passed instead
+        if ``tnames`` is supplied.
+    :param priors: list of prior specifications, i.e. ``setup.theta_prior``.
+        Entries with a ``name`` key are independent priors on a single
+        parameter; entries with a ``names`` key are joint priors evaluated
+        with a user-supplied ``log_density_fn``.
+    :param tnames: optional parameter names, used when ``theta`` is an array.
+    :return: array of length ntemps with the summed log prior.  When no
+        priors have been set this is a vector of zeros, so calibration is
+        unaffected.
+    """
+    if tnames is not None and not isinstance(theta, dict):
+        theta = dict(zip(tnames, np.asarray(theta).T))
+
+    ntemps = np.atleast_1d(next(iter(theta.values()))).shape[0]
+    lp = np.zeros(ntemps)
+    if not priors:
+        return lp
+
+    for p in priors:
+        if p.get("names") is not None:
+            # joint prior: hand the named parameters to the user's function
+            params_list = {nm: np.atleast_1d(theta[nm]) for nm in p["names"]}
+            add = p["log_density_fn"](params_list)
+        else:
+            # independent prior on a single parameter
+            x = np.atleast_1d(theta[p["name"]])
+            try:
+                logpdf = THETA_PRIOR_LOGPDF[p["dist"]]
+            except KeyError:
+                raise ValueError(f"Unsupported dist: {p['dist']}") from None
+            add = logpdf(x, p["params"])
+
+        lp = lp + np.broadcast_to(np.asarray(add, dtype=float), lp.shape)
+
+    # a NaN density (e.g. a proposal outside the support of the prior) is
+    # treated as zero probability rather than propagating into alpha
+    return np.where(np.isnan(lp), -np.inf, lp)
+
+
+def theta_log_prior(setup, theta_mat):
+    """Log prior of a (ntemps, p) matrix of unit-scaled calibration parameters.
+
+    Returns zeros (with no work done) when no prior has been added to
+    ``setup``, so that the samplers behave exactly as they did before.
+    """
+    priors = getattr(setup, "theta_prior", None)
+    if not priors:
+        return np.zeros(np.atleast_2d(theta_mat).shape[0])
+    return eval_theta_priors(
+        tran_unif(theta_mat, setup.bounds_mat, setup.bounds.keys()), priors
+    )
+
+
 class CalibSetup:
     """
     Structure for storing calibration experimental data, likelihood, discrepancy, etc.
     Includes the following methods:
 
     * addVecExperiments
+    * addThetaPrior
+    * addJointThetaPrior
     * setTemperatureLadder
     * setMCMC
     * setHierPriors
@@ -114,6 +211,103 @@ class CalibSetup:
         self.constants = None
         self.theta0_start = None  # optional
         self.theta_start = None  # optional
+        self.theta_prior = []  # optional priors for theta, see addThetaPrior
+
+    def addThetaPrior(self, dist="uniform", params=None, pname=None):
+        """Add a prior distribution for a single calibration parameter.
+
+        Without a prior, each calibration parameter is implicitly uniform on
+        the bounds given to :class:`CalibSetup`.  Any parameter left without
+        an explicit prior keeps that behavior.
+
+        :param dist: name of the distribution.  One of 'normal', 'lognormal',
+            'beta', 'uniform', 'gamma', 'cauchy'.
+        :param params: dict of distribution parameters, on the native
+            (unnormalized) scale of the calibration parameter:
+
+            * normal: 'mean', 'sd'
+            * lognormal: 'meanlog', 'sdlog'
+            * beta: 'shape1', 'shape2'
+            * uniform: 'min', 'max'
+            * gamma: 'shape', 'rate'
+            * cauchy: 'location', 'scale'
+
+        :param pname: name of the calibration parameter, i.e. one of the keys
+            of the bounds dict given to :class:`CalibSetup`.
+        :return: the `CalibSetup` object (modified in place, returned so that
+            calls may be chained).
+
+        Note that the prior is truncated to the bounds of the parameter, since
+        proposals outside the bounds are rejected by the constraint function.
+        """
+        if params is None:
+            params = {"min": 0.0, "max": 1.0}
+        if pname is None or pname not in self.bounds:
+            raise ValueError(
+                "No parameter name given, or parameter not in the set of "
+                "input names for any model in setup."
+            )
+        if dist not in THETA_PRIOR_LOGPDF:
+            raise ValueError(
+                f"Unsupported dist: {dist}.  Supported distributions are "
+                f"{sorted(THETA_PRIOR_LOGPDF)}."
+            )
+        missing = [k for k in THETA_PRIOR_PARAMS[dist] if k not in params]
+        if missing:
+            raise ValueError(
+                f"Missing parameters {missing} for dist '{dist}'; expected "
+                f"{list(THETA_PRIOR_PARAMS[dist])}."
+            )
+
+        self.theta_prior.append({
+            "name": pname,
+            "dist": dist,
+            "params": dict(params),
+        })
+        return self
+
+    def addJointThetaPrior(self, pnames, log_density_fn):
+        """Add a joint prior over several calibration parameters.
+
+        :param pnames: list of calibration parameter names the joint prior
+            applies to; each must be a key of the bounds dict given to
+            :class:`CalibSetup`.
+        :param log_density_fn: function taking a dict that maps each name in
+            `pnames` to an array of length ntemps of native-scale parameter
+            values, and returning the log density, either as a scalar or as an
+            array of length ntemps.
+        :return: the `CalibSetup` object (modified in place, returned so that
+            calls may be chained).
+
+        For example, a bivariate normal prior on 't_1' and 't_2'::
+
+            from scipy.stats import multivariate_normal
+
+            def joint_prior(params):
+                x = np.column_stack((params['t_1'], params['t_2']))
+                return multivariate_normal.logpdf(
+                    x, mean=[0, 0], cov=[[1, 0.5], [0.5, 1]]
+                )
+
+            setup.addJointThetaPrior(['t_1', 't_2'], joint_prior)
+        """
+        if isinstance(pnames, str):
+            pnames = [pnames]
+        pnames = list(pnames)
+        invalid = [nm for nm in pnames if nm not in self.bounds]
+        if invalid:
+            raise ValueError(
+                f"Parameter names {invalid} are not in the set of input "
+                "names for any model in setup."
+            )
+        if not callable(log_density_fn):
+            raise TypeError("log_density_fn must be callable")
+
+        self.theta_prior.append({
+            "names": pnames,
+            "log_density_fn": log_density_fn,
+        })
+        return self
 
     def checkConstraints(self, x, *args):
         """Calls the constraint function set by the user. Argument x contains the parameters to be checked
@@ -2525,6 +2719,10 @@ def calibPool(setup):
                 setup.ys[i], pred_curr[i][t], marg_lik_cov_curr[i][t]
             )
 
+    # current log-prior for theta at each temperature (zeros if no prior set)
+    lpr_curr = theta_log_prior(setup, theta[0])
+    lpr_cand = lpr_curr.copy()
+
     # eps  = 1.0e-13
     # tau  = np.repeat(-4.0, setup.ntemps)
     # AM_const   = 2.4**2/setup.p
@@ -2642,6 +2840,7 @@ def calibPool(setup):
         # get predictions and SSE
         pred_cand = [_.copy() for _ in pred_curr]
         llik_cand[:] = llik_curr.copy()
+        lpr_cand = theta_log_prior(setup, theta_cand)
         if np.any(good_values):
             llik_cand[:, good_values] = 0.0
             for i in range(setup.nexp):
@@ -2663,15 +2862,17 @@ def calibPool(setup):
                     )  # (((pred_cand[i] - setup.ys[i])**2 @ s2_ind_mat[i]) / s2[i][m-1]).sum(axis = 1)
 
         # tsq_diff = 0.#((theta_cand * theta_cand).sum(axis = 1) - (theta[m-1] * theta[m-1]).sum(axis = 1))[good_values]
-        llik_diff = (llik_cand.sum(axis=0) - llik_curr.sum(axis=0))[
-            good_values
-        ]  # sum over experiments
+        llik_diff = (
+            (llik_cand.sum(axis=0) + lpr_cand)
+            - (llik_curr.sum(axis=0) + lpr_curr)
+        )[good_values]  # sum over experiments
         # ------------------------------------------------------------------------------------------
         # for each temperature, accept or reject
         alpha[:] = -np.inf
         alpha[good_values] = setup.itl[good_values] * (llik_diff)
         for t in np.where(np.log(uniform(size=setup.ntemps)) < alpha)[0]:
             theta[m, t] = theta_cand[t].copy()
+            lpr_curr[t] = lpr_cand[t]
             count[t, t] += 1
             for i in range(setup.nexp):
                 llik_curr[i, t] = llik_cand[i, t].copy()
@@ -2702,6 +2903,7 @@ def calibPool(setup):
                 )
                 pred_cand = [_.copy() for _ in pred_curr]
                 llik_cand[:] = llik_curr.copy()
+                lpr_cand = theta_log_prior(setup, theta_cand)
 
                 if np.any(good_values):
                     llik_cand[:, good_values] = 0.0
@@ -2725,9 +2927,10 @@ def calibPool(setup):
 
                 alpha[:] = -np.inf
                 # tsq_diff = 0.#((theta_cand * theta_cand).sum(axis = 1) - (theta[m] * theta[m]).sum(axis = 1))[good_values]
-                llik_diff = (llik_cand.sum(axis=0) - llik_curr.sum(axis=0))[
-                    good_values
-                ]
+                llik_diff = (
+                    (llik_cand.sum(axis=0) + lpr_cand)
+                    - (llik_curr.sum(axis=0) + lpr_curr)
+                )[good_values]
                 alpha[good_values] = (
                     setup.itl[good_values] * (llik_diff)
                 )  # + tsq_diff) + 0.5 * tsq_diff # last is for proposal, since this is an independence sampler step
@@ -2735,6 +2938,7 @@ def calibPool(setup):
                     0
                 ]:
                     theta[m, t, k] = theta_cand[t, k].copy()
+                    lpr_curr[t] = lpr_cand[t]
                     count_decor[k, t] += 1
                     for i in range(setup.nexp):
                         pred_curr[i][t] = pred_cand[i][t].copy()
@@ -2830,6 +3034,9 @@ def calibPool(setup):
                     llik_curr[:, sw.T[0]].sum(axis=0)
                     - llik_curr[:, sw.T[1]].sum(axis=0)
                 )
+                sw_alpha += (setup.itl[sw.T[1]] - setup.itl[sw.T[0]]) * (
+                    lpr_curr[sw.T[0]] - lpr_curr[sw.T[1]]
+                )
                 for i in range(setup.nexp):
                     sw_alpha += (setup.itl[sw.T[1]] - setup.itl[sw.T[0]]) * (
                         setup.s2_prior_kern[i](
@@ -2893,6 +3100,10 @@ def calibPool(setup):
                     theta[m][tt[0]], theta[m][tt[1]] = (
                         theta[m][tt[1]].copy(),
                         theta[m][tt[0]].copy(),
+                    )
+                    lpr_curr[tt[0]], lpr_curr[tt[1]] = (
+                        lpr_curr[tt[1]],
+                        lpr_curr[tt[0]],
                     )
 
         llik[m] = llik_curr[:, 0].sum()
@@ -3018,6 +3229,10 @@ def calibPool_v2(setup):
                 setup.ys[i], pred_curr[i][t], marg_lik_cov_curr[i][t], wt_mat[i]
             )
 
+    # current log-prior for theta at each temperature (zeros if no prior set)
+    lpr_curr = theta_log_prior(setup, theta[0])
+    lpr_cand = lpr_curr.copy()
+
     # eps  = 1.0e-13
     # tau  = np.repeat(-4.0, setup.ntemps)
     # AM_const   = 2.4**2/setup.p
@@ -3115,6 +3330,7 @@ def calibPool_v2(setup):
         # get predictions and SSE
         pred_cand = [_.copy() for _ in pred_curr]
         llik_cand[:] = llik_curr.copy()
+        lpr_cand = theta_log_prior(setup, theta_cand)
         if np.any(good_values):
             llik_cand[:, good_values] = 0.0
             for i in range(setup.nexp):
@@ -3134,15 +3350,17 @@ def calibPool_v2(setup):
                         wt_mat[i],
                     )
 
-        llik_diff = (llik_cand.sum(axis=0) - llik_curr.sum(axis=0))[
-            good_values
-        ]  # sum over experiments
+        llik_diff = (
+            (llik_cand.sum(axis=0) + lpr_cand)
+            - (llik_curr.sum(axis=0) + lpr_curr)
+        )[good_values]  # sum over experiments
         # ------------------------------------------------------------------------------------------
         # for each temperature, accept or reject
         alpha[:] = -np.inf
         alpha[good_values] = setup.itl[good_values] * (llik_diff)
         for t in np.where(np.log(uniform(size=setup.ntemps)) < alpha)[0]:
             theta[m, t] = theta_cand[t].copy()
+            lpr_curr[t] = lpr_cand[t]
             count[t, t] += 1
             for i in range(setup.nexp):
                 llik_curr[i, t] = llik_cand[i, t].copy()
@@ -3168,6 +3386,7 @@ def calibPool_v2(setup):
                 )
                 pred_cand = [_.copy() for _ in pred_curr]
                 llik_cand[:] = llik_curr.copy()
+                lpr_cand = theta_log_prior(setup, theta_cand)
 
                 if np.any(good_values):
                     llik_cand[:, good_values] = 0.0
@@ -3192,9 +3411,10 @@ def calibPool_v2(setup):
 
                 alpha[:] = -np.inf
                 # tsq_diff = 0.#((theta_cand * theta_cand).sum(axis = 1) - (theta[m] * theta[m]).sum(axis = 1))[good_values]
-                llik_diff = (llik_cand.sum(axis=0) - llik_curr.sum(axis=0))[
-                    good_values
-                ]
+                llik_diff = (
+                    (llik_cand.sum(axis=0) + lpr_cand)
+                    - (llik_curr.sum(axis=0) + lpr_curr)
+                )[good_values]
                 alpha[good_values] = (
                     setup.itl[good_values] * (llik_diff)
                 )  # + tsq_diff) + 0.5 * tsq_diff # last is for proposal, since this is an independence sampler step
@@ -3202,6 +3422,7 @@ def calibPool_v2(setup):
                     0
                 ]:
                     theta[m, t, k] = theta_cand[t, k].copy()
+                    lpr_curr[t] = lpr_cand[t]
                     count_decor[k, t] += 1
                     for i in range(setup.nexp):
                         pred_curr[i][t] = pred_cand[i][t].copy()
@@ -3398,6 +3619,9 @@ def calibPool_v2(setup):
                     llik_curr[:, sw.T[0]].sum(axis=0)
                     - llik_curr[:, sw.T[1]].sum(axis=0)
                 )
+                sw_alpha += (setup.itl[sw.T[1]] - setup.itl[sw.T[0]]) * (
+                    lpr_curr[sw.T[0]] - lpr_curr[sw.T[1]]
+                )
                 for i in range(setup.nexp):
                     sw_alpha += (setup.itl[sw.T[1]] - setup.itl[sw.T[0]]) * (
                         setup.s2_prior_kern[i](
@@ -3461,6 +3685,10 @@ def calibPool_v2(setup):
                     theta[m][tt[0]], theta[m][tt[1]] = (
                         theta[m][tt[1]].copy(),
                         theta[m][tt[0]].copy(),
+                    )
+                    lpr_curr[tt[0]], lpr_curr[tt[1]] = (
+                        lpr_curr[tt[1]],
+                        lpr_curr[tt[0]],
                     )
 
         llik[m] = llik_curr[:, 0].sum()

--- a/tests/test_theta_prior.py
+++ b/tests/test_theta_prior.py
@@ -1,0 +1,282 @@
+import numpy as np
+import pytest
+from numpy import ndarray
+from scipy.stats import beta as Beta
+from scipy.stats import multivariate_normal
+from scipy.stats import norm as Normal
+
+from impala import superCal as sc
+from impala.superCal.impala_noprobit_emu import (
+    eval_theta_priors,
+    theta_log_prior,
+)
+
+
+class Line:
+    """y = t_0 * grid + t_1, a model with an analytically obvious posterior."""
+
+    def __init__(self, grid: ndarray) -> None:
+        self.grid = grid
+
+    def __call__(self, theta: ndarray) -> ndarray:
+        return theta[0] * self.grid + theta[1]
+
+
+def make_setup(bounds=None):
+    if bounds is None:
+        bounds = {"t_0": np.array([0.0, 1.0]), "t_1": np.array([0.0, 1.0])}
+    return sc.CalibSetup(bounds, constraint_func="bounds")
+
+
+def test_no_prior_is_zero_and_default_empty():
+    setup = make_setup()
+    assert setup.theta_prior == []
+    theta = np.random.rand(5, 2)
+    lp = theta_log_prior(setup, theta)
+    assert lp.shape == (5,)
+    assert np.all(lp == 0.0)
+
+
+def test_independent_priors_match_scipy():
+    bounds = {"t_0": np.array([0.0, 4.0]), "t_1": np.array([0.0, 1.0])}
+    setup = make_setup(bounds)
+    setup.addThetaPrior(
+        dist="normal", params={"mean": 2.0, "sd": 0.5}, pname="t_0"
+    )
+    setup.addThetaPrior(
+        dist="beta", params={"shape1": 2.0, "shape2": 5.0}, pname="t_1"
+    )
+    assert len(setup.theta_prior) == 2
+
+    # unit-scaled draws, as held by the sampler
+    theta = np.array([[0.25, 0.10], [0.50, 0.90], [0.75, 0.50]])
+    # native scale, per the bounds above
+    t0 = theta[:, 0] * 4.0
+    t1 = theta[:, 1]
+
+    expected = Normal(2.0, 0.5).logpdf(t0) + Beta(2.0, 5.0).logpdf(t1)
+    np.testing.assert_allclose(theta_log_prior(setup, theta), expected)
+
+
+@pytest.mark.parametrize(
+    ("dist", "params"),
+    [
+        ("normal", {"mean": 0.5, "sd": 1.0}),
+        ("lognormal", {"meanlog": 0.0, "sdlog": 1.0}),
+        ("beta", {"shape1": 2.0, "shape2": 2.0}),
+        ("uniform", {"min": 0.0, "max": 1.0}),
+        ("gamma", {"shape": 2.0, "rate": 3.0}),
+        ("cauchy", {"location": 0.5, "scale": 1.0}),
+    ],
+)
+def test_all_supported_dists_are_finite_and_normalized(dist, params):
+    setup = make_setup()
+    setup.addThetaPrior(dist=dist, params=params, pname="t_0")
+    theta = np.linspace(0.01, 0.99, 25)[:, None]
+    theta = np.column_stack((theta, np.full_like(theta, 0.5)))
+    lp = theta_log_prior(setup, theta)
+    assert lp.shape == (25,)
+    assert np.all(np.isfinite(lp))
+    # crude check that the density integrates to <= 1 over [0, 1]
+    assert np.trapezoid(np.exp(lp), theta[:, 0]) <= 1.0 + 1e-8
+
+
+def test_joint_prior():
+    setup = make_setup()
+
+    def joint_prior(params):
+        x = np.column_stack((params["t_0"], params["t_1"]))
+        return multivariate_normal.logpdf(
+            x, mean=[0.5, 0.5], cov=[[1.0, 0.5], [0.5, 1.0]]
+        )
+
+    setup.addJointThetaPrior(["t_0", "t_1"], joint_prior)
+
+    theta = np.array([[0.2, 0.3], [0.5, 0.5], [0.9, 0.1]])
+    expected = multivariate_normal.logpdf(
+        theta, mean=[0.5, 0.5], cov=[[1.0, 0.5], [0.5, 1.0]]
+    )
+    np.testing.assert_allclose(theta_log_prior(setup, theta), expected)
+
+
+def test_joint_and_independent_priors_add():
+    setup = make_setup()
+    setup.addThetaPrior(
+        dist="normal", params={"mean": 0.5, "sd": 0.2}, pname="t_0"
+    )
+    setup.addJointThetaPrior(["t_0", "t_1"], lambda params: -1.0)
+
+    theta = np.array([[0.4, 0.6], [0.5, 0.5]])
+    expected = Normal(0.5, 0.2).logpdf(theta[:, 0]) - 1.0
+    np.testing.assert_allclose(theta_log_prior(setup, theta), expected)
+
+
+def test_scalar_joint_prior_broadcasts():
+    setup = make_setup()
+    setup.addJointThetaPrior(["t_0", "t_1"], lambda params: -2.5)
+    lp = theta_log_prior(setup, np.random.rand(4, 2))
+    np.testing.assert_allclose(lp, np.full(4, -2.5))
+
+
+def test_out_of_support_is_neg_inf():
+    setup = make_setup()
+    setup.addThetaPrior(
+        dist="gamma", params={"shape": 2.0, "rate": 1.0}, pname="t_0"
+    )
+    theta = np.array([[0.0, 0.5]])
+    assert theta_log_prior(setup, theta)[0] == -np.inf
+
+
+def test_eval_theta_priors_accepts_names():
+    priors = [
+        {
+            "name": "t_0",
+            "dist": "normal",
+            "params": {
+                "mean": 0.0,
+                "sd": 1.0,
+            },
+        }
+    ]
+    theta = np.array([[0.0, 9.0], [1.0, 9.0]])
+    lp = eval_theta_priors(theta, priors, tnames=["t_0", "t_1"])
+    np.testing.assert_allclose(lp, Normal(0.0, 1.0).logpdf([0.0, 1.0]))
+
+
+def test_bad_input_raises():
+    setup = make_setup()
+    with pytest.raises(ValueError):
+        setup.addThetaPrior(dist="normal", params={"mean": 0, "sd": 1})
+    with pytest.raises(ValueError):
+        setup.addThetaPrior(
+            dist="normal", params={"mean": 0, "sd": 1}, pname="nope"
+        )
+    with pytest.raises(ValueError):
+        setup.addThetaPrior(dist="weibull", params={}, pname="t_0")
+    with pytest.raises(ValueError):
+        setup.addThetaPrior(dist="normal", params={"mean": 0}, pname="t_0")
+    with pytest.raises(ValueError):
+        setup.addJointThetaPrior(["t_0", "nope"], lambda params: 0.0)
+    with pytest.raises(TypeError):
+        setup.addJointThetaPrior(["t_0"], "not a function")
+    with pytest.raises(ValueError):
+        eval_theta_priors(
+            {"t_0": np.zeros(3)},
+            [{"name": "t_0", "dist": "weibull", "params": {}}],
+        )
+
+
+def build_line_setup(yobs, model, nmcmc=6000):
+    bounds = {"t_0": np.array([0.0, 1.0]), "t_1": np.array([0.0, 1.0])}
+    setup = sc.CalibSetup(bounds, constraint_func="bounds")
+    setup.addVecExperiments(
+        yobs=yobs,
+        model=model,
+        sd_est=[0.1],
+        s2_df=[0],
+        s2_ind=[0] * len(yobs),
+    )
+    setup.setTemperatureLadder(1.05 ** np.arange(8))
+    setup.setMCMC(nmcmc=nmcmc, decor=100)
+    return setup
+
+
+def test_calibPool_prior_shifts_posterior():
+    """A tight prior away from the MLE should pull the posterior toward it."""
+    np.random.seed(0)
+    grid = np.linspace(0, 1, 40)
+    line = Line(grid)
+    model = sc.ModelF(line, input_names=["t_0", "t_1"])
+    truth = np.array([0.8, 0.2])
+    yobs = np.random.normal(line(truth), 0.1)
+
+    np.random.seed(1)
+    out_flat = sc.calibPool(build_line_setup(yobs, model))
+
+    np.random.seed(1)
+    setup = build_line_setup(yobs, model)
+    setup.addThetaPrior(
+        dist="normal", params={"mean": 0.2, "sd": 0.02}, pname="t_0"
+    )
+    out_prior = sc.calibPool(setup)
+
+    burn = 3000
+    flat_mean = out_flat.theta[burn:, 0, 0].mean()
+    prior_mean = out_prior.theta[burn:, 0, 0].mean()
+
+    # without a prior the posterior sits near the truth
+    assert abs(flat_mean - truth[0]) < 0.1
+    # with a tight prior at 0.2 the posterior is pulled well away from it
+    assert prior_mean < flat_mean - 0.2
+
+
+def test_calibPool_recovers_prior_with_no_information():
+    """With a flat likelihood, the posterior should look like the prior."""
+    np.random.seed(0)
+    grid = np.linspace(0, 1, 20)
+
+    # model ignores theta entirely, so the likelihood carries no information
+    class Constant:
+        def __call__(self, theta):
+            return np.zeros_like(grid) + 0.0 * theta[0]
+
+    model = sc.ModelF(Constant(), input_names=["t_0", "t_1"])
+    yobs = np.random.normal(0.0, 0.1, 20)
+
+    setup = build_line_setup(yobs, model, nmcmc=8000)
+    setup.addThetaPrior(
+        dist="beta", params={"shape1": 3.0, "shape2": 6.0}, pname="t_0"
+    )
+    np.random.seed(2)
+    out = sc.calibPool(setup)
+
+    draws = out.theta[4000::2, 0, 0]
+    prior = Beta(3.0, 6.0)
+    assert abs(draws.mean() - prior.mean()) < 0.05
+    assert abs(draws.std() - prior.std()) < 0.05
+
+    # t_1 has no prior, so it should still be uniform
+    draws1 = out.theta[4000::2, 0, 1]
+    assert abs(draws1.mean() - 0.5) < 0.05
+
+
+def test_calibPool_v2_prior_shifts_posterior():
+    np.random.seed(0)
+    grid = np.linspace(0, 1, 30)
+    line = Line(grid)
+    model = sc.ModelF(line, input_names=["t_0", "t_1"])
+    yobs = np.random.normal(line(np.array([0.8, 0.2])), 0.1)
+
+    np.random.seed(1)
+    out_flat = sc.calibPool_v2(build_line_setup(yobs, model, nmcmc=3000))
+
+    setup = build_line_setup(yobs, model, nmcmc=3000)
+    setup.addThetaPrior(
+        dist="normal", params={"mean": 0.2, "sd": 0.02}, pname="t_0"
+    )
+    np.random.seed(1)
+    out_prior = sc.calibPool_v2(setup)
+
+    flat_mean = out_flat.theta[1500:, 0, 0].mean()
+    prior_mean = out_prior.theta[1500:, 0, 0].mean()
+    assert prior_mean < flat_mean - 0.2
+    assert abs(prior_mean - 0.2) < 0.05
+
+
+def test_calibPool_unchanged_without_prior():
+    """No prior set => bitwise-identical results to the pre-prior sampler."""
+    np.random.seed(0)
+    grid = np.linspace(0, 1, 30)
+    line = Line(grid)
+    model = sc.ModelF(line, input_names=["t_0", "t_1"])
+    yobs = np.random.normal(line(np.array([0.8, 0.2])), 0.1)
+
+    np.random.seed(3)
+    out_a = sc.calibPool(build_line_setup(yobs, model, nmcmc=2000))
+
+    setup = build_line_setup(yobs, model, nmcmc=2000)
+    setup.theta_prior = []
+    np.random.seed(3)
+    out_b = sc.calibPool(setup)
+
+    np.testing.assert_array_equal(out_a.theta, out_b.theta)

--- a/tests/test_theta_prior.py
+++ b/tests/test_theta_prior.py
@@ -11,7 +11,7 @@ from impala.superCal.impala_noprobit_emu import (
     theta_log_prior,
 )
 
-if np.version<'2':
+if np.version < "2":
     np.trapezoid = np.trapz
 
 

--- a/tests/test_theta_prior.py
+++ b/tests/test_theta_prior.py
@@ -11,7 +11,7 @@ from impala.superCal.impala_noprobit_emu import (
     theta_log_prior,
 )
 
-if np.version < "2":
+if np.lib.NumpyVersion(np.__version__) < "2.0.0":
     np.trapezoid = np.trapz
 
 

--- a/tests/test_theta_prior.py
+++ b/tests/test_theta_prior.py
@@ -11,6 +11,9 @@ from impala.superCal.impala_noprobit_emu import (
     theta_log_prior,
 )
 
+if np.version<'2':
+    np.trapezoid = np.trapz
+
 
 class Line:
     """y = t_0 * grid + t_1, a model with an analytically obvious posterior."""


### PR DESCRIPTION
Port of rImpala PR #8 (sandialabs/rImpala#8, "priors for calibration parameters") to the python implementation.

By default each calibration parameter is implicitly uniform over the bounds given to CalibSetup.  This adds the ability to place an explicit prior on theta:

  * CalibSetup.addThetaPrior(dist, params, pname) -- an independent prior on a single parameter, from 'normal', 'lognormal', 'beta', 'uniform', 'gamma' or 'cauchy'.  Distribution and parameter names match the R arguments (which follow R's d* functions) so the two interfaces stay in sync.
  * CalibSetup.addJointThetaPrior(pnames, log_density_fn) -- a joint prior over several parameters, evaluated by a user-supplied function.

eval_theta_priors() evaluates the summed log prior over the native-scale parameters (the analogue of the R helper of the same name); theta_log_prior() wraps it for the samplers and short-circuits to zeros when no prior has been added, so runs without priors are unchanged.

calibPool and calibPool_v2 now carry lpr_curr / lpr_cand alongside the log likelihood and include them in

  * the adaptive Metropolis acceptance ratio for theta,
  * the decorrelation-step acceptance ratio, and
  * the tempering swap probability (the log prior is swapped with theta).

Adds tests/test_theta_prior.py, which checks the densities against scipy, checks that a flat likelihood recovers the prior, and checks that results are bitwise identical to the previous sampler when no prior is set.